### PR TITLE
"Contains" should have parameters swapped and support strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/landau/predicate.svg)](https://travis-ci.org/landau/predicate)
+[![Build Status](https://travis-ci.org/jadbox/predicate.svg)](https://travis-ci.org/landau/predicate)
 [![NPM](https://nodei.co/npm/predicate.png?downloads=true&stars=true)](https://nodei.co/npm/predicate/)
 # predicate.js - Adding clarity and conciseness to your JS through predicates
 

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -143,7 +143,7 @@ predicate.odd = function (val) {
 };
 
 predicate.contains = curry(function (arr, val) {
-  if (!predicate.array(arr)) throw new TypeError('Expected an array');
+  if (!predicate.array(arr) || typeof arr !== 'string') throw new TypeError('Expected an array or string');
   if (predicate.NaN(val)) {
     return arr.some(predicate.NaN);
   }

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -143,7 +143,6 @@ predicate.odd = function (val) {
 };
 
 predicate.contains = curry(function (val, arr) {
-  console.log(typeof arr);
   if (!predicate.array(arr) && typeof arr !== 'string') throw new TypeError('Expected an array or string');
   if (predicate.NaN(val)) {
     return arr.some(predicate.NaN);

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -143,7 +143,7 @@ predicate.odd = function (val) {
 };
 
 predicate.contains = curry(function (val, arr) {
-  if (!predicate.array(arr) || typeof arr !== 'string') throw new TypeError('Expected an array or string');
+  if (!predicate.array(arr) && typeof arr !== 'string') throw new TypeError('Expected an array or string');
   if (predicate.NaN(val)) {
     return arr.some(predicate.NaN);
   }

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -143,6 +143,7 @@ predicate.odd = function (val) {
 };
 
 predicate.contains = curry(function (val, arr) {
+  console.log(typeof arr);
   if (!predicate.array(arr) && typeof arr !== 'string') throw new TypeError('Expected an array or string');
   if (predicate.NaN(val)) {
     return arr.some(predicate.NaN);

--- a/lib/predicates.js
+++ b/lib/predicates.js
@@ -142,7 +142,7 @@ predicate.odd = function (val) {
           predicate.not.zero(utils.mod(val, 2));
 };
 
-predicate.contains = curry(function (arr, val) {
+predicate.contains = curry(function (val, arr) {
   if (!predicate.array(arr) || typeof arr !== 'string') throw new TypeError('Expected an array or string');
   if (predicate.NaN(val)) {
     return arr.some(predicate.NaN);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predicate",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A set of predicate functions to improve your value testing and comparisons.",
   "scripts": {
     "pretest": "jshint --reporter node_modules/jshint-stylish/stylish.js index.js ./test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predicate",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A set of predicate functions to improve your value testing and comparisons.",
   "scripts": {
     "pretest": "jshint --reporter node_modules/jshint-stylish/stylish.js index.js ./test",

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -318,16 +318,23 @@ describe('predicate', function() {
   describe('#contains', function() {
     var arr;
     arr = [1, 2, 3];
+    var arrStr = 'Joe';
 
     it('should return false if the value is not found', function() {
-      predicate.contains(arr, 5).should.be.false;
+      predicate.contains(5, arr).should.be.false;
+      predicate.contains('z', arrStr).should.be.false;
     });
 
     it('should return true if the value is found', function() {
-      predicate.contains(arr, 1).should.be.true;
-      predicate.contains(arr, 2).should.be.true;
-      predicate.contains(arr, 3).should.be.true;
-      predicate.contains([0, NaN], NaN).should.be.true;
+      predicate.contains(1, arr).should.be.true;
+      predicate.contains(2, arr).should.be.true;
+      predicate.contains(3, arr).should.be.true;
+
+      predicate.contains('J', arrStr).should.be.true;
+      predicate.contains('o', arrStr).should.be.true;
+      predicate.contains('e', arrStr).should.be.true;
+
+      predicate.contains(NaN, [0, NaN]).should.be.true;
     });
   });
 
@@ -407,9 +414,9 @@ describe('predicate', function() {
 
     it('should allow chaining', function() {
       predicate.every().equal(1, 1).str('5').val().should.be.ok;
-      predicate.every().str('foo').contains([1, 2, 3], 1).val().should.be.ok;
-      predicate.every().str(1).contains([1, 2, 3], 1).val().should.be.false;
-      predicate.every().str('foo').contains([1, 2, 3], 5).val().should.be.false;
+      predicate.every().str('foo').contains(1, [1, 2, 3]).val().should.be.ok;
+      predicate.every().str(1).contains(1, [1, 2, 3]).val().should.be.false;
+      predicate.every().str('foo').contains(5, [1, 2, 3]).val().should.be.false;
     });
   });
 
@@ -424,10 +431,10 @@ describe('predicate', function() {
 
     it('should allow chaining', function() {
       predicate.some().equal(1, 1).str('5').val().should.be.ok;
-      predicate.some().str('foo').contains([1, 2, 3], 1).val().should.be.ok;
-      predicate.some().str(1).contains([1, 2, 3], 1).val().should.be.ok;
-      predicate.some().str('foo').contains([1, 2, 3], 5).val().should.be.ok;
-      predicate.some().num('foo').contains([1, 2, 3], 5).val().should.be.false;
+      predicate.some().str('foo').contains(1, [1, 2, 3]).val().should.be.ok;
+      predicate.some().str(1).contains(1, [1, 2, 3]).val().should.be.ok;
+      predicate.some().str('foo').contains(5, [1, 2, 3]).val().should.be.ok;
+      predicate.some().num('foo').contains(5, [1, 2, 3]).val().should.be.false;
     });
   });
 


### PR DESCRIPTION
The function was written with the interface contains(arr, item) but most functional libraries like Rx take the predicate under the assumtion that the last parameter is the list to be searched. I've changed that function to contains(item, arr). 

Also, I added string support as the arr param and added unit tests for it.
