### PR TITLE
fix: drop support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"


### PR DESCRIPTION
BREAKING CHANGE: Node 8 is no longer LTS